### PR TITLE
chore: docker repository name

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       docker_repo:
-        default: codexstorage/discord-bot
+        default: codexstorage/testnet-bot
         description: DockerHub repository
         required: false
         type: string


### PR DESCRIPTION
As we discussed, a proper name of the bot should be `testnet-bot` and it make sense to update Docker repository name as well.